### PR TITLE
按钮样式修复

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 由于个人水平有限所以可能会出现许多意料之外的 bug ，欢迎在 Issues 提出。
 
+视频：[https://www.bilibili.com/video/BV1XmLFz5E7Y](https://www.bilibili.com/video/BV1XmLFz5E7Y)
+
 ## 部署指南
 
 #### 环境要求

--- a/web/src/styles/Guess.css
+++ b/web/src/styles/Guess.css
@@ -1,0 +1,38 @@
+.guess {
+    margin-top: -2%;
+    margin-left: 5%;
+    margin-right: 5%;
+    font-size: 3rem;
+}
+
+.inputlayout {
+    display: flex;
+    text-align: center;
+    justify-content: center;
+}
+
+.inputbox {
+    display: flex;
+    justify-content: center;
+    gap: 2rem;
+    width: 60%;
+}
+
+.times {
+    color: rgb(144, 147, 153);
+    padding-top: 10px;
+    font-size: 1.5rem;
+}
+
+.setting {
+    margin-left: 5%;
+    margin-right: 5%;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.el-tag {
+    font-size: 17px;
+    margin: 2px 2px;
+}

--- a/web/src/views/Guess.vue
+++ b/web/src/views/Guess.vue
@@ -127,12 +127,12 @@
                         :trigger-on-focus="false"
                         style="width: 100%"></el-autocomplete>
                     </el-col>
-                    <el-col :xs="5" :sm="4" :md="4" :lg="3" :xl="2">
+                    <el-col :xs="5" :sm="4" :md="3" :lg="3" :xl="2">
                         <el-button type="primary" style="width: 100%" :disabled="this.gameover" @click="Guess()">
                             {{ this.gameover ? '已结束' : '确定' }}
                         </el-button>
                     </el-col>
-                    <el-col :xs="5" :sm="4" :md="4" :lg="3" :xl="2">
+                    <el-col :xs="5" :sm="4" :md="3" :lg="3" :xl="2">
                         <el-button type="success" style="width: 100%" @click="Restart()">重新开始</el-button>
                     </el-col>
                     <!-- <el-col :span="12"><div class="grid-content bg-purple">aaa</div></el-col>

--- a/web/src/views/Guess.vue
+++ b/web/src/views/Guess.vue
@@ -127,20 +127,20 @@
                         :trigger-on-focus="false"
                         style="width: 100%"></el-autocomplete>
                     </el-col>
-                    <el-col :span="2">
+                    <el-col :xs="5" :sm="4" :md="4" :lg="3" :xl="2">
                         <el-button type="primary" style="width: 100%" :disabled="this.gameover" @click="Guess()">
                             {{ this.gameover ? '已结束' : '确定' }}
                         </el-button>
                     </el-col>
-                    <el-col :span="2">
+                    <el-col :xs="5" :sm="4" :md="4" :lg="3" :xl="2">
                         <el-button type="success" style="width: 100%" @click="Restart()">重新开始</el-button>
                     </el-col>
                     <!-- <el-col :span="12"><div class="grid-content bg-purple">aaa</div></el-col>
                     <el-col :span="12"><div class="grid-content bg-purple-light">bbb</div></el-col> -->
                 </el-row>
-                <div class="times">
+                <el-row class="times">
                     猜测次数：{{this.times}}/{{this.settings.maxguess}}
-                </div>
+                </el-row>
                 <el-table
                 :data="tableData"
                 style="width: 100%"
@@ -773,6 +773,7 @@
         width: 60%;
     }
     .times{
+        color: rgb(144, 147, 153);
         font-size: 1.5rem;
     }
     .setting{

--- a/web/src/views/Guess.vue
+++ b/web/src/views/Guess.vue
@@ -175,10 +175,10 @@
                     align="center"
                     v-if="settings.shapeOpen">
                         <template slot-scope="scope">
-                            <el-tag style="font-size: 17px" :type="scope.row.shape.col">
+                            <el-tag :type="scope.row.shape.col">
                                 {{ scope.row.shape.key }}
                             </el-tag>
-                            <el-tag style="font-size: 17px" :type="scope.row.col.col">
+                            <el-tag :type="scope.row.col.col">
                                 {{ scope.row.col.key }}
                             </el-tag>
                         </template>
@@ -190,7 +190,7 @@
                     align="center">
                         <template slot-scope="scope">
                             <a v-for="item in scope.row.type">
-                                <el-tag style="font-size: 17px" :type="item.col">
+                                <el-tag :type="item.col">
                                     {{ item.key }}
                                 </el-tag>
                             </a>
@@ -202,16 +202,16 @@
                     min-width="150"
                     align="center">
                         <template slot-scope="scope">
-                            <el-tag style="font-size: 17px" :type="scope.row.pow.col">
+                            <el-tag :type="scope.row.pow.col">
                                 {{ ValueText(scope.row.pow.key,scope.row.pow.value) }}
                             </el-tag>
-                            <el-tag style="font-size: 17px" :type="scope.row.speed.col" v-if="settings.battleOpen">
+                            <el-tag :type="scope.row.speed.col" v-if="settings.battleOpen">
                                 速度:{{ ValueText(scope.row.speed.key,scope.row.speed.value) }}
                             </el-tag>
-                            <el-tag style="font-size: 17px" :type="scope.row.attack.col" v-if="settings.battleOpen">
+                            <el-tag :type="scope.row.attack.col" v-if="settings.battleOpen">
                                 {{ scope.row.attack.key }}
                             </el-tag>
-                            <el-tag style="font-size: 17px" :type="scope.row.defense.col" v-if="settings.battleOpen">
+                            <el-tag :type="scope.row.defense.col" v-if="settings.battleOpen">
                                 {{ scope.row.defense.key }}
                             </el-tag>
                         </template>
@@ -222,7 +222,7 @@
                     min-width="120"
                     align="center">
                         <template slot-scope="scope">
-                            <el-tag style="font-size: 17px" :type="scope.row.gen.col">
+                            <el-tag :type="scope.row.gen.col">
                                 {{ ValueText(scope.row.gen.key,scope.row.gen.value) }}
                             </el-tag>
                         </template>
@@ -234,7 +234,7 @@
                     align="center">
                         <template slot-scope="scope">
                             <a v-for="item in scope.row.ability">
-                                <el-tag style="font-size: 17px" :type="item.col">
+                                <el-tag :type="item.col">
                                     {{ item.key }}
                                 </el-tag>
                             </a>
@@ -246,10 +246,10 @@
                     min-width="170"
                     align="center">
                         <template slot-scope="scope">
-                            <el-tag style="font-size: 17px" :type="scope.row.evo.col" v-if="scope.row.evo.key!=null">
+                            <el-tag :type="scope.row.evo.col" v-if="scope.row.evo.key!=null">
                                 {{ scope.row.evo.key }}
                             </el-tag>
-                            <el-tag style="font-size: 17px" :type="scope.row.stage.col">
+                            <el-tag :type="scope.row.stage.col">
                                 {{ scope.row.stage.key }}
                             </el-tag>
                         </template>
@@ -262,11 +262,11 @@
                     v-if="settings.catchOpen">
                         <template slot-scope="scope">
                             <a v-for="item in scope.row.egg">
-                                <el-tag style="font-size: 17px" :type="item.col">
+                                <el-tag :type="item.col">
                                     {{ item.key }}
                                 </el-tag>
                             </a>
-                            <el-tag style="font-size: 17px" :type="scope.row.catrate.col">
+                            <el-tag :type="scope.row.catrate.col">
                                 捕获率:{{ ValueText(scope.row.catrate.key,scope.row.catrate.value) }}
                             </el-tag>
                         </template>
@@ -293,6 +293,7 @@
 <script>
     import axios from 'axios'
     import { MessageBox } from 'element-ui';
+    import '../styles/Guess.css'
 
     function truncateString(str, maxLength) {
         if (str.length > maxLength) {
@@ -761,36 +762,3 @@
         }
     }
 </script>
-
-<style>
-
-    .guess{
-        margin-top: -2%;
-        margin-left: 5%;
-        margin-right: 5%;
-        font-size: 3rem;
-    }
-    .inputlayout{
-        display: flex;
-        text-align: center;
-        justify-content: center;
-    }
-    .inputbox{
-        display: flex;
-        justify-content: center;
-        gap: 2rem;
-        width: 60%;
-    }
-    .times{
-        color: rgb(144, 147, 153);
-        padding-top:10px;
-        font-size: 1.5rem;
-    }
-    .setting{
-        margin-left: 5%;
-        margin-right: 5%;
-        display: flex;
-        flex-direction: column;
-        gap: 8px;
-    }
-</style>

--- a/web/src/views/Guess.vue
+++ b/web/src/views/Guess.vue
@@ -128,7 +128,7 @@
                         style="width: 100%"></el-autocomplete>
                     </el-col>
                     <el-col :xs="5" :sm="4" :md="3" :lg="3" :xl="2">
-                        <el-button type="primary" style="width: 100%" :disabled="this.gameover" @click="Guess()">
+                        <el-button type="primary" style="width: 100%" :disabled="this.gameover || this.isGuessing" @click="Guess()">
                             {{ this.gameover ? '已结束' : '确定' }}
                         </el-button>
                     </el-col>
@@ -139,7 +139,8 @@
                     <el-col :span="12"><div class="grid-content bg-purple-light">bbb</div></el-col> -->
                 </el-row>
                 <el-row class="times">
-                    猜测次数：{{this.times}}/{{this.settings.maxguess}}
+                    <span style="padding-right:10px">猜测次数：{{this.times}}/{{this.settings.maxguess}}</span>
+                    <el-button style="text-align" type="danger" :disabled="this.gameover" @click="Surrender()">投降🏳️</el-button>
                 </el-row>
                 <el-table
                 :data="tableData"
@@ -313,6 +314,7 @@
                 gameover:false,
                 settingVisble:false,
                 introVisble:false,
+                isGuessing:false,
                 gens:["全世代","第一世代","第二世代","第三世代","第四世代","第五世代","第六世代","第七世代","第八世代","第九世代"],
                 hards:["普通模式","简单模式"],
                 settings:{
@@ -414,6 +416,7 @@
             async Guess(){
                 const answer=sessionStorage.getItem('answer')
                 if(answer==null)return;
+                this.isGuessing = true
                 try{
                     const options = {
                         method: 'GET',
@@ -609,6 +612,8 @@
                 }catch(error){
                     console.error(error)
                 }
+                this.input = ''
+                this.isGuessing = false
             },
             ValueText(key,value){
                 if(value=='high')
@@ -705,6 +710,10 @@
                     console.error(error)
                 }
             },
+            Surrender(){
+                this.gameover = true;
+                this.ReplayAnswer();
+            },
             CloseSetting(){
                 this.saveSettings();
                 this.settingVisble=false;
@@ -774,6 +783,7 @@
     }
     .times{
         color: rgb(144, 147, 153);
+        padding-top:10px;
         font-size: 1.5rem;
     }
     .setting{


### PR DESCRIPTION
修复了一些小窗口时按钮显示的样式。
统一了猜测字数的颜色。
修改前：
![image](https://github.com/user-attachments/assets/be78cce6-61a7-48ea-8cfa-8f8367b35bd6)
修改后：
![image](https://github.com/user-attachments/assets/f0af00fd-698b-4016-a15b-14fb285b64c0)
